### PR TITLE
Fix bad instruction when url not found in realm.

### DIFF
--- a/LGTM/Queue.swift
+++ b/LGTM/Queue.swift
@@ -66,6 +66,11 @@ extension Queue: RangeReplaceableCollectionType {
     }
 }
 func shuffle<T>(array:[T]) -> [T] {
+
+    guard !array.isEmpty else {
+        return []
+    }
+    
     var result:[T] = []
     for i in 1...array.count {
         let r = Int(arc4random_uniform(UInt32(array.count - i)))


### PR DESCRIPTION
初回起動時など、Realm に URL が保存されていない場合に BAD INSTRUCTION 例外でアプリが落ちる不具合を修正しました。